### PR TITLE
Issue #9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,6 @@ buildscript {
 
 // apply plugin: 'com.google.gms.google-services'
 // class must be used instead of id(string) to be able to apply plugin from non-root gradle file
-ext.postBuildExtras = {
+cdvPluginPostBuildExtras.add({
     apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
-}
+})


### PR DESCRIPTION
## Description
Replace usage of `ext.postBuildExtras` with usage of `cdvPluginPostBuildExtras`.

## Related Issue
Issue #9

## Motivation and Context
This improves inter-compatibility with other Cordova plugins.