### PR TITLE
Use cdvPluginPostBuildExtras instead to avoid conflicts with other plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,8 @@ buildscript {
 
 // apply plugin: 'com.google.gms.google-services'
 // class must be used instead of id(string) to be able to apply plugin from non-root gradle file
-ext.postBuildExtras = {
-    apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
-}
+cdvPluginPostBuildExtras.add({
+    if(project.plugins.findPlugin("com.google.gms.google-services") == null) {
+        apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+    }
+})


### PR DESCRIPTION
- Use cdvPluginPostBuildExtras instead of postBuildExtras to avoid conflict against other plugins.
  - Setting postBuildExtras directly will overwrite things and may cause problems.
- Check the existence of 'com.google.gms.google-services' before apply, so it can coexist with other plugins which also applies google services plugin.