### PR TITLE
Fix error Could not find org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.60-eap-25 - Missing Kotlin Maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ buildscript {
         google()
         jcenter()
         mavenCentral()
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,10 @@ buildscript {
         google()
         jcenter()
         mavenCentral()
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:+'
+        classpath 'com.android.tools.build:gradle:3.+'
         classpath 'com.google.gms:google-services:4.2.0'
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-support-google-services",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Cordova plugin to add google service support",
   "scripts": {
     "version": "replace -s 'version=\"(.+)(?=\">)' 'version=\"'$npm_package_version plugin.xml && git add plugin.xml",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-support-google-services"
-      version="1.3.1">
+      version="1.3.2">
 
     <name>cordova-support-google-services</name>
     <description>Cordova plugin to add google service support</description>


### PR DESCRIPTION
This fixes the error: "Could not find org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.60-eap-25." 
adding the Kotlin Maven repository, as described here: https://androidstudio.googleblog.com/2019/10/android-studio-40-canary-1-available.html

This was tested with this environment:


------------------------------------------------------------
Gradle 5.3.1
------------------------------------------------------------

Build time:   2019-03-28 09:09:23 UTC
Revision:     f2fae6ba563cfb772c8bc35d31e43c59a5b620c3

Kotlin:       1.3.21
Groovy:       2.5.4
Ant:          Apache Ant(TM) version 1.9.13 compiled on July 10 2018
JVM:          1.8.0_192 (Oracle Corporation 25.192-b12)
OS:           Mac OS X 10.14.6 x86_64

Apache Maven 3.6.0 (97c98ec64a1fdfee7767ce5ffb20918da4f719f3; 2018-10-24T13:41:47-05:00)
OS name: "mac os x", version: "10.14.6", arch: "x86_64", family: "mac"
-  Ionic CLI 4.12.0
- Cordova: 9.0.0 (cordova-lib@9.0.1)

----

Update 24/OCT: I've just fixed the **gradle version to 3.+**, avoiding adding the new maven repository, still working with the same environment, and also with Android Studio 4.0 Canary. As many of you say, this is a better solution for this issue
