### PR TITLE
com.android.tools.build:gradle:3.5.1 instead of +

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:+'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath 'com.google.gms:google-services:4.2.0'
     }
 }


### PR DESCRIPTION
Caution: You should not use dynamic dependencies in version numbers, such as 'com.android.tools.build:gradle:2.+'. Using this feature can cause unexpected version updates and difficulty resolving version differences.

https://developer.android.com/studio/releases/gradle-plugin