### PR TITLE
Update the build.gradle file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,10 @@ buildscript {
 // cdvPluginPostBuildExtras. Therefore if googleServices is added
 // to cdvPluginPostBuildExtras somewhere else, the plugin execution
 // will be skipped and project build will be successfull
-ext.postBuildExtras = {
+cdvPluginPostBuildExtras.add({
     if (project.extensions.findByName('googleServices') == null) {
         // apply plugin: 'com.google.gms.google-services'
         // class must be used instead of id(string) to be able to apply plugin from non-root gradle file
         apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
     }
-}
+})


### PR DESCRIPTION
Cordova Jira Ticket Exapling the Bug this fixes
https://issues.apache.org/jira/browse/CB-14163

We had trouble using this plugin on android with other plugins that also try to use ext.postBuildExtras.
We had cordova-support-google-services and cordova-plugin-code-push installed as well as this plugin and all three were trying to use postBuildExtras.
But only the last plugin listed in our config file would have its code executed at built time. the link above describes the cause of the issue pretty well